### PR TITLE
Fix ch5/c-fibers for macOS

### DIFF
--- a/ch5/c-fibers/src/main.rs
+++ b/ch5/c-fibers/src/main.rs
@@ -153,6 +153,7 @@ pub fn yield_thread() {
 
 #[naked]
 #[no_mangle]
+#[cfg_attr(target_os = "macos", export_name = "\x01switch")]
 unsafe extern "C" fn switch() {
     asm!(
         "mov [rdi + 0x00], rsp",


### PR DESCRIPTION
Currently, ch5/c-fibers does not work on amd64 macOS.

https://github.com/rust-lang/rust/issues/35052#issuecomment-235420755