### PR TITLE
make each project a workspace

### DIFF
--- a/ch01/a-assembly-dereference/Cargo.toml
+++ b/ch01/a-assembly-dereference/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "ac-assembly-dereference"
 version = "0.1.0"

--- a/ch02/a-os-threads/Cargo.toml
+++ b/ch02/a-os-threads/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-os-threads"
 version = "0.1.0"

--- a/ch03/a-raw-syscall/Cargo.toml
+++ b/ch03/a-raw-syscall/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-raw-syscall"
 version = "0.1.0"

--- a/ch03/b-normal-syscall/Cargo.toml
+++ b/ch03/b-normal-syscall/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-normal-syscall"
 version = "0.1.0"

--- a/ch04/a-epoll/Cargo.toml
+++ b/ch04/a-epoll/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-epoll"
 version = "0.1.0"

--- a/ch04/b-epoll-mio/Cargo.toml
+++ b/ch04/b-epoll-mio/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-epoll-mio"
 version = "0.1.0"

--- a/ch05/a-stack-swap/Cargo.toml
+++ b/ch05/a-stack-swap/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-stack-swap"
 version = "0.1.0"

--- a/ch05/b-show-stack/Cargo.toml
+++ b/ch05/b-show-stack/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-show-stack"
 version = "0.1.0"

--- a/ch05/c-fibers/Cargo.toml
+++ b/ch05/c-fibers/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "c-fibers"
 version = "0.1.0"

--- a/ch05/d-fibers-closure/Cargo.toml
+++ b/ch05/d-fibers-closure/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "d-fibers-closure"
 version = "0.1.0"

--- a/ch05/e-fibers-windows/Cargo.toml
+++ b/ch05/e-fibers-windows/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "e-fibers-windows"
 version = "0.1.0"

--- a/ch07/a-coroutine-bonus/Cargo.toml
+++ b/ch07/a-coroutine-bonus/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-coroutine-bonus"
 version = "0.1.0"

--- a/ch07/a-coroutine/Cargo.toml
+++ b/ch07/a-coroutine/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-coroutine"
 version = "0.1.0"

--- a/ch07/b-async-await/Cargo.toml
+++ b/ch07/b-async-await/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-async-await"
 version = "0.1.0"

--- a/ch07/c-async-await/Cargo.toml
+++ b/ch07/c-async-await/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "c-async-await"
 version = "0.1.0"

--- a/ch07/corofy/Cargo.toml
+++ b/ch07/corofy/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "corofy"
 version = "0.1.0"

--- a/ch08/a-runtime/Cargo.toml
+++ b/ch08/a-runtime/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-runtime"
 version = "0.1.0"

--- a/ch08/b-reactor-executor/Cargo.toml
+++ b/ch08/b-reactor-executor/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-reactor-executor"
 version = "0.1.0"

--- a/ch08/c-reactor-executor/Cargo.toml
+++ b/ch08/c-reactor-executor/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "c-reactor-executor"
 version = "0.1.0"

--- a/ch08/d-multiple-threads/Cargo.toml
+++ b/ch08/d-multiple-threads/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "d-multiple-threads"
 version = "0.1.0"

--- a/ch09/a-coroutines-variables/Cargo.toml
+++ b/ch09/a-coroutines-variables/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-coroutines-variables"
 version = "0.1.0"

--- a/ch09/b-coroutines-references/Cargo.toml
+++ b/ch09/b-coroutines-references/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-coroutines-references"
 version = "0.1.0"

--- a/ch09/c-coroutines-problem/Cargo.toml
+++ b/ch09/c-coroutines-problem/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "c-coroutines-problem"
 version = "0.1.0"

--- a/ch09/d-pin/Cargo.toml
+++ b/ch09/d-pin/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "d-pin"
 version = "0.1.0"

--- a/ch09/e-coroutines-pin/Cargo.toml
+++ b/ch09/e-coroutines-pin/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "e-coroutines-pin"
 version = "0.1.0"

--- a/ch10/a-rust-futures-bonus/Cargo.toml
+++ b/ch10/a-rust-futures-bonus/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-rust-futures-bonus"
 version = "0.1.0"

--- a/ch10/a-rust-futures/Cargo.toml
+++ b/ch10/a-rust-futures/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "a-rust-futures"
 version = "0.1.0"

--- a/ch10/b-rust-futures-experiments/Cargo.toml
+++ b/ch10/b-rust-futures-experiments/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "b-rust-futures-experiments"
 version = "0.1.0"

--- a/ch10/parker-bonus/Cargo.toml
+++ b/ch10/parker-bonus/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "parker-bonus"
 version = "0.1.0"

--- a/delayserver/Cargo.toml
+++ b/delayserver/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "delayserver"
 version = "0.1.0"


### PR DESCRIPTION
This fixes the error "current package believes it's in a workspace", if the repository was cloned inside the directory structure of another workspace, as explained in cargo issue 5418.

It doesn't affect anything else and will make the projects compile more reliably under those special conditions.