### PR TITLE
[ch01] Add option for aarch64 and unverified architecture

### DIFF
--- a/ch01/a-assembly-dereference/src/main.rs
+++ b/ch01/a-assembly-dereference/src/main.rs
@@ -13,8 +13,17 @@ fn main() {
 
 fn dereference(ptr: *const usize) -> usize {
     let mut res: usize;
-    unsafe { 
-        asm!("mov {0}, [{1}]", out(reg) res, in(reg) ptr)
+    unsafe {
+        #[cfg(target_arch = "x86_64")]
+        asm!("mov {0}, [{1}]", out(reg) res, in(reg) ptr);
+
+        #[cfg(target_arch = "aarch64")]
+        asm!("mov {0}, {1}", out(reg) res, in(reg) ptr);
+
+        if !(cfg!(target_arch = "aarch64") || cfg!(target_arch = "x86_64"))
+        {
+            panic!("Unverified architecture")
+        }
     };
     res
 }


### PR DESCRIPTION
This change should allow the code from chapter 1 to compile and run on both a Mac/aarch64 as well as on x86_64 targets.

The syntax of the `mov` command appears to be slightly different.
Reference - [this cheat sheet](https://www.cs.swarthmore.edu/~kwebb/cs31/resources/ARM64_Cheat_Sheet.pdf).

I compiled and ran this on my laptop (`aarch64-apple-darwin`).
I have not verified this runs on Windows/Linux.