### PR TITLE
Fix target_arch for x86_64

### DIFF
--- a/ch01/a-assembly-dereference/src/main.rs
+++ b/ch01/a-assembly-dereference/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     println!("{}", x);
 }
 
-#[cfg(target_arch = "x86-64")]
+#[cfg(target_arch = "x86_64")]
 fn dereference(ptr: *const usize) -> usize {
     let mut res: usize;
     unsafe {


### PR DESCRIPTION
The target_arch should be `x86_64` as mentioned here https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch

Otherwise the compilation is broken on wsl with x86_64-unknown-linux-gnu target