### PR TITLE
Ch 04 - Solution for Mac users that want to run the epoll examples using docker

### DIFF
--- a/ch04/a-epoll/Dockerfile
+++ b/ch04/a-epoll/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1-slim-bookworm
+
+WORKDIR /usr/a-epoll
+
+COPY . .
+
+RUN cargo build
+
+CMD ["cargo", "run", "delayserver"]

--- a/ch04/a-epoll/README.md
+++ b/ch04/a-epoll/README.md
@@ -5,6 +5,9 @@ additional comments that's not in the book.
 
 You can run the example by simply writing `cargo run`
 
+If running on a Mac system (which only supports kqueue but not epoll), docker
+can be used to run the example by running the epoll_docker.sh script
+
 ## Note
 
 There is one downside of having a local server on the same machine to mimic

--- a/ch04/a-epoll/docker-compose.yml
+++ b/ch04/a-epoll/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  delayserver:
+    build: ../../delayserver/
+    ports:
+      - "8080:8080"
+    networks:
+      - delayserver_network
+
+  epoll:
+    build: .
+    depends_on:
+      - delayserver
+    networks:
+      - delayserver_network
+
+networks:
+  delayserver_network: {}

--- a/ch04/a-epoll/epoll_docker.sh
+++ b/ch04/a-epoll/epoll_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose up --build

--- a/ch04/a-epoll/src/main.rs
+++ b/ch04/a-epoll/src/main.rs
@@ -17,6 +17,7 @@ use std::{
     collections::HashSet,
     io::{self, Read, Result, Write},
     net::TcpStream,
+    env
 };
 
 use ffi::Event;
@@ -84,13 +85,21 @@ fn main() -> Result<()> {
     let n_events = 5;
 
     let mut streams = vec![];
-    let addr = "localhost:8080";
+
+    let args: Vec<String> = env::args().collect();
+    let base_url;
+    if args.len() > 1 {
+        base_url = args[1].clone();
+    } else {
+        base_url = String::from("localhost");
+    }
+    let addr = format!("{}:8080", &base_url);
 
     for i in 0..n_events {
         let delay = (n_events - i) * 1000;
         let url_path = format!("/{delay}/request-{i}");
         let request = get_req(&url_path);
-        let mut stream = std::net::TcpStream::connect(addr)?;
+        let mut stream = std::net::TcpStream::connect(&addr)?;
         stream.set_nonblocking(true)?;
 
         stream.write_all(request.as_bytes())?;

--- a/ch04/b-epoll-mio/Dockerfile
+++ b/ch04/b-epoll-mio/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1-slim-bookworm
+
+WORKDIR /usr/a-epoll
+
+COPY . .
+
+RUN cargo build
+
+CMD ["cargo", "run", "delayserver"]

--- a/ch04/b-epoll-mio/README.md
+++ b/ch04/b-epoll-mio/README.md
@@ -1,9 +1,12 @@
-# a-epoll-mio
+# b-epoll-mio
 
 This create contains the example code for chapter 4, but instead of using
 our own queue, we use one created by [mio](https://github.com/tokio-rs/mio). Since we modelled our own code after
 mio you only need to make a few very minor changes to get it working which I've
 commented and marked out as clearly as I can.
+
+If running on a Mac system (which only supports kqueue but not epoll), docker
+can be used to run the example by running the epoll_mio_docker.sh script
 
 You can run the example by simply writing `cargo run`
 

--- a/ch04/b-epoll-mio/docker-compose.yml
+++ b/ch04/b-epoll-mio/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  delayserver:
+    build: ../../delayserver/
+    ports:
+      - "8080:8080"
+    networks:
+      - delayserver_network
+
+  epoll-mio:
+    build: .
+    depends_on:
+      - delayserver
+    networks:
+      - delayserver_network
+
+networks:
+  delayserver_network: {}

--- a/ch04/b-epoll-mio/epoll_mio_docker.sh
+++ b/ch04/b-epoll-mio/epoll_mio_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose up --build

--- a/delayserver/Dockerfile
+++ b/delayserver/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1-slim-bookworm
+
+WORKDIR /usr/delayserver
+
+COPY . .
+
+RUN cargo build
+
+CMD ["cargo", "run", "delayserver"]

--- a/delayserver/docker-compose.yml
+++ b/delayserver/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  delayserver:
+    build: .
+    ports:
+      - 8080
+    networks:
+      - network1
+
+networks:
+  network1: {}

--- a/delayserver/src/main.rs
+++ b/delayserver/src/main.rs
@@ -1,10 +1,13 @@
-use std::{time::Duration, sync::atomic::{AtomicUsize, Ordering}};
+use std::{time::Duration, sync::atomic::{AtomicUsize, Ordering}, env};
 use actix_web::{Responder, get, HttpServer, App, web, rt::time::sleep};
 
 const EXPLANATION: &str =
 "USAGE:
 Delay server works by issuing a http GET request in the format:
 http://localhost:8080/[delay in ms]/[UrlEncoded meesage]
+
+If an argument is passed in when delayserver is started, that
+argument will be used as the url instead of 'localhost'
 
 On reception, it immidiately reports the following to the console:
 {Message #} - {delay in ms}: {message}
@@ -27,12 +30,19 @@ async fn delay(path: web::Path<(u64, String)>) -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let url;
+    if args.len() > 1 {
+        url = args[1].clone();
+    } else {
+        url = String::from("localhost");
+    }
     println!("{EXPLANATION}");
     HttpServer::new(|| {
         App::new()
         .service(delay)
     })
-    .bind(("127.0.0.1", 8080))?
+    .bind((url, 8080))?
     .run()
     .await
 }


### PR DESCRIPTION
# Enable Running on Macs

## Overview
Since Mac (and to a lesser extent Windows, though it has WSL) cannot work with epoll directly, Dockerfiles, Docker compose yml, and simple run scripts have been created so that users who have docker can run and test the ch04 examples on their system.

## Details

A docker file has been created for delayserver as well and docker compose is used to run an epoll container and a delay server container and coordinate the network between them.

Some slight modification has been made to the epoll code to allow for an optional argument to be passed in which is the name of the host. When running the examples without docker and no arguments passed in (i.e. `cargo run`) "localhost" will be used by default. However when running docker containers epoll and delayserver are in separate containers, so epoll needs to transmit to the delayserver container (conveniently named "delayserver") instead of localhost. The dockerfiles supply the correct argument for the user.

Debian slim rust containers have been used as they are a convenient and fairly small container for these kinds of rust projects.

README.md's have been updated to note that it is now possible to pass an optional argument for the hostname to connect to, which will default to "localhost" if no argument is passed.

## Further Comments

I've supplied this as a convenience for perhaps other mac users who may pick up this book. Hopefully it doesn't unnecessarily clutter up the code base.