### PR TITLE
less verbose way to get base_url from env::args

### DIFF
--- a/ch04/a-epoll/src/main.rs
+++ b/ch04/a-epoll/src/main.rs
@@ -84,13 +84,10 @@ fn main() -> Result<()> {
 
     let mut streams = vec![];
 
-    let args: Vec<String> = env::args().collect();
-    let base_url;
-    if args.len() > 1 {
-        base_url = args[1].clone();
-    } else {
-        base_url = String::from("localhost");
-    }
+    let base_url = env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("localhost"));
+
     let addr = format!("{}:8080", &base_url);
 
     for i in 0..n_events {

--- a/ch04/b-epoll-mio/src/main.rs
+++ b/ch04/b-epoll-mio/src/main.rs
@@ -91,13 +91,10 @@ fn main() -> Result<()> {
 
     let mut streams = vec![];
 
-    let args: Vec<String> = env::args().collect();
-    let base_url;
-    if args.len() > 1 {
-        base_url = args[1].clone();
-    } else {
-        base_url = String::from("localhost");
-    }
+    let base_url = env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("localhost"));
+
     let addr = format!("{}:8080", &base_url);
 
     for i in 0..n_events {


### PR DESCRIPTION
That's a matter of taste, but imho it's a more idiomatic way to get single positional arg.

Following is just for history, if one don't want to allocate "localhost" on the heap. However using Cow in the context of this example is a bit of overkill. 
```rust
let base_url = env::args().nth(1).map_or(Cow::from("localhost"), Cow::from);
```