### PR TITLE
simplify url retrieval in delayserver

### DIFF
--- a/delayserver/src/main.rs
+++ b/delayserver/src/main.rs
@@ -31,13 +31,10 @@ async fn delay(path: web::Path<(u64, String)>) -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let args: Vec<String> = env::args().collect();
-    let url;
-    if args.len() > 1 {
-        url = args[1].clone();
-    } else {
-        url = String::from("localhost");
-    }
+    let url = env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("localhost"));
+    
     println!("{EXPLANATION}");
     HttpServer::new(|| {
         App::new()


### PR DESCRIPTION
The a-epoll/src/main.rs already had the same change made, I am simply extending it to the delayserver. See linked commit.

https://github.com/PacktPublishing/Asynchronous-Programming-in-Rust/commit/2275e6a65415908c8ad98579e398c37a4d178403

