### PR TITLE
fix issue #27

### DIFF
--- a/ch07/a-coroutine/src/main.rs
+++ b/ch07/a-coroutine/src/main.rs
@@ -1,7 +1,6 @@
 use std::{
     thread,
-    time::Duration,
-    Instant
+    time::Duration
 };
 
 mod future;


### PR DESCRIPTION
Fixes issue #27. This was changed by Packt due to an erratum by Packt, but there must somehow be a misunderstanding, since the "fix" breaks the example. Let me know @rajdeep-packt if there is any reason to importing `Instant` here?