### PR TITLE
ch05: use stablized `naked_functions` feature

### DIFF
--- a/ch05/c-fibers/README.md
+++ b/ch05/c-fibers/README.md
@@ -14,8 +14,9 @@ run the example just fine.
 
 ## Running the example
 
-This example uses the unstable feature "naked_functions" so we need to run it
-using nightly Rust. There are two ways to do that.
+This example uses the feature "naked_functions" so we need to run it using
+nightly Rust until https://github.com/rust-lang/rust/pull/134213 is released in
+stable Rust. There are two ways to do that.
 
 1. Tell cargo to use the nightly toolchain when you run the program:
 

--- a/ch05/c-fibers/src/main.rs
+++ b/ch05/c-fibers/src/main.rs
@@ -6,7 +6,6 @@
 ///
 /// See: https://github.com/PacktPublishing/Asynchronous-Programming-in-Rust/issues/31
 /// for more information.
-#![feature(naked_functions)]
 use std::arch::{asm, naked_asm};
 
 const DEFAULT_STACK_SIZE: usize = 1024 * 1024 * 2;
@@ -147,7 +146,7 @@ fn guard() {
     };
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn skip() {
     naked_asm!("ret")
 }
@@ -159,7 +158,7 @@ pub fn yield_thread() {
     };
 }
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[cfg_attr(target_os = "macos", export_name = "\x01switch")] // see: How-to-MacOS-M.md for explanation
 unsafe extern "C" fn switch() {
@@ -199,11 +198,16 @@ fn main() {
     runtime.spawn(|| {
         println!("THREAD 2 STARTING");
         let id = 2;
-        for i in 0..15 {
+        for i in 0..7 {
+            println!("thread: {} counter: {}", id, i);
+        }
+        yield_thread();
+        for i in 7..15 {
             println!("thread: {} counter: {}", id, i);
             yield_thread();
         }
         println!("THREAD 2 FINISHED");
     });
+
     runtime.run();
 }

--- a/ch05/d-fibers-closure/README.md
+++ b/ch05/d-fibers-closure/README.md
@@ -22,8 +22,9 @@ run the example just fine.
 
 ## Running the example
 
-This example uses the unstable feature "naked_functions" so we need to run it
-using nightly Rust. There are two ways to do that.
+This example uses the feature "naked_functions" so we need to run it using
+nightly Rust until https://github.com/rust-lang/rust/pull/134213 is released in
+stable Rust. There are two ways to do that.
 
 1. Tell cargo to use the nightly toolchain when you run the program:
 

--- a/ch05/d-fibers-closure/src/main.rs
+++ b/ch05/d-fibers-closure/src/main.rs
@@ -6,7 +6,6 @@
 ///
 /// See: https://github.com/PacktPublishing/Asynchronous-Programming-in-Rust/issues/31
 /// for more information.
-#![feature(naked_functions)]
 use std::{arch::{asm, naked_asm}};
 
 const DEFAULT_STACK_SIZE: usize = 1024 * 1024 * 2;
@@ -159,7 +158,7 @@ fn call(thread: u64) {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn skip() {
     naked_asm!("ret")
 }
@@ -180,7 +179,7 @@ pub fn yield_thread() {
         (*rt_ptr).t_yield();
     };
 }
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[cfg_attr(target_os = "macos", export_name = "\x01switch")]
 unsafe extern "C" fn switch() {

--- a/ch05/e-fibers-windows/README.md
+++ b/ch05/e-fibers-windows/README.md
@@ -13,8 +13,9 @@ AMD desktop CPU's use this architecture).
 
 ## Running the example
 
-This example uses the unstable feature "naked_functions" so we need to run it
-using nightly Rust. There are two ways to do that.
+This example uses the feature "naked_functions" so we need to run it using
+nightly Rust until https://github.com/rust-lang/rust/pull/134213 is released in
+stable Rust. There are two ways to do that.
 
 1. Tell cargo to use the nightly toolchain when you run the program:
 

--- a/ch05/e-fibers-windows/src/main.rs
+++ b/ch05/e-fibers-windows/src/main.rs
@@ -6,7 +6,6 @@
 ///
 /// See: https://github.com/PacktPublishing/Asynchronous-Programming-in-Rust/issues/31
 /// for more information.
-#![feature(naked_functions)]
 use std::arch::{asm, naked_asm};
 
 const DEFAULT_STACK_SIZE: usize = 1024 * 1024 * 2;
@@ -151,7 +150,7 @@ impl Runtime {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn skip() {
     naked_asm!("ret")
 }
@@ -172,7 +171,7 @@ pub fn yield_thread() {
 }
 
 #[cfg(not(target_os = "windows"))]
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[cfg_attr(target_os = "macos", export_name = "\x01switch")]
 unsafe extern "C" fn switch() {
@@ -278,7 +277,7 @@ impl Runtime {
 // reference: https://probablydance.com/2013/02/20/handmade-coroutines-for-windows/
 // Contents of TIB on Windows: https://en.wikipedia.org/wiki/Win32_Thread_Information_Block
 #[cfg(target_os = "windows")]
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 unsafe extern "C" fn switch() {
     asm!(


### PR DESCRIPTION
The `naked_functions` feature was stabilized in https://github.com/rust-lang/rust/pull/134213. Update the code to use this stabilized feature. This still requires nightly Rust until https://github.com/rust-lang/rust/pull/134213 is released in stable Rust.